### PR TITLE
Fix CI: releasetools/cli renamed the rt binary to releasetools

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Set the correct (tag) version
         run: |
-          VERSION="$(rt git::version_or_sha)"
+          VERSION="$(releasetools git::version_or_sha)"
           echo "Updating version in '$VERSION_FILE' to: $VERSION" >&2
           echo "$VERSION" > ./VERSION
 
@@ -189,7 +189,7 @@ jobs:
           REPO_NAME=$(echo "${{ github.repository }}" | cut -d '/' -f 2)
           echo "REPO_NAME=$REPO_NAME" >> "$GITHUB_ENV"
 
-          VERSION="$(rt git::version_or_sha)"
+          VERSION="$(releasetools git::version_or_sha)"
           echo "Updating version in '$VERSION_FILE' to: $VERSION" >&2
           echo "$VERSION" > ./VERSION
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
@@ -287,7 +287,7 @@ jobs:
           REPO_NAME=$(echo "${{ github.repository }}" | cut -d '/' -f 2)
           echo "REPO_NAME=$REPO_NAME" >> "$GITHUB_ENV"
 
-          VERSION="$(rt git::version_or_sha)"
+          VERSION="$(releasetools git::version_or_sha)"
           echo "Updating version in '$VERSION_FILE' to: $VERSION" >&2
           echo "$VERSION" > ./VERSION
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"

--- a/scripts/helm-set-version.bash
+++ b/scripts/helm-set-version.bash
@@ -7,7 +7,7 @@ readonly DIR
 # shellcheck disable=SC1091
 source "$DIR/functions.bash"
 
-VERSION="$(rt git::latest_version)"
+VERSION="$(releasetools git::latest_version)"
 readonly VERSION
 
 cat "$DIR"/../charts/waf-downloader/Chart.yaml.tmpl >"$DIR"/../charts/waf-downloader/Chart.yaml


### PR DESCRIPTION
## Summary
- `releasetools/cli` v0.0.12 stopped symlinking an `rt` executable and only exposes `releasetools` now (both via the GitHub Action's `install.sh` and the Homebrew formula). This repo's CI still called `rt`, so `pre-commit run --all-files` (the `helm-lint` hook, via `scripts/helm-set-version.bash`) failed with `rt: command not found` in every job.
- Updates `scripts/helm-set-version.bash` and the three `rt git::version_or_sha` calls in `.github/workflows/cicd.yml` (build, push-docker, push-ghcr jobs) to use `releasetools` instead.

## Root cause
Confirmed by diffing the action's `install.sh` across releases: `EXEC_NAME` was `rt` through v0.0.11 and became `releasetools` in v0.0.12 (2025-09-06). The `releasetools/cli@v0` action floats to latest, so CI silently picked up the rename while the workflow/scripts here were never updated.

## Test plan
- [x] Ran `scripts/helm-set-version.bash` locally with `releasetools` on PATH — succeeds, writes `Chart.yaml`
- [x] Ran `task helm-lint` locally — passes (only a pre-existing, unrelated SemVer format warning)
- [ ] CI (`Run linters` step) goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)