### PR TITLE
Group psycopg, GitHub Actions and Python tooling Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>MihaiBojin/renovate"]
+  "extends": [
+    "github>MihaiBojin/renovate",
+    "github>MihaiBojin/renovate:group-psycopg",
+    "github>MihaiBojin/renovate:group-github-actions",
+    "github>MihaiBojin/renovate:group-python-tooling"
+  ]
 }


### PR DESCRIPTION
## Summary
Turns on three new grouping profiles from the shared [`MihaiBojin/renovate`](https://github.com/MihaiBojin/renovate) preset:

- **`group-psycopg`** — `psycopg`, `psycopg-binary`, `psycopg_pool` released in lockstep by the psycopg project. This repo's history shows them bumped same-day or within days of each other 5 separate times (14 PRs total).
- **`group-github-actions`** — non-major updates to actions used in `.github/workflows/cicd.yml`. Just today, 4 `docker/*` actions and 6 core `actions/*`/`azure`/`arduino` actions each opened as separate PRs in the same batch.
- **`group-python-tooling`** — `build`, `pip`, `pre-commit`, `pytest`, `toml`, `twine`, `wheel`, `wheel-inspect` in `requirements-dev.txt`. None of these touch runtime behavior; ~25 individual PRs across the repo's history for the lowest-blast-radius updates it has.

Security-flagged updates are unaffected — Renovate keeps `vulnerabilityAlerts` PRs out of custom `groupName` groups by default (`isVulnerabilityAlert: true` is applied separately from `packageRules`), so patches like the currently open `pytest`/`requests`/`pip` `[SECURITY]` PRs keep shipping individually and immediately.

Majors are intentionally excluded from all three groups (`matchUpdateTypes: ["minor", "patch", "pin", "digest"]`) and still need individual review.

## Test plan
- [x] `npx --yes --package renovate@latest -- renovate-config-validator renovate.json` passes
- [ ] Next Renovate run opens grouped PRs instead of one-per-package for the above families

🤖 Generated with [Claude Code](https://claude.com/claude-code)