### PR TITLE
Read pyproject.toml with tomllib, raise the floor to 3.11

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout code

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -63,7 +63,7 @@ tasks:
     deps: [build]
     vars:
       PROJECT_NAME:
-        sh: python -c "import toml; print(toml.load('pyproject.toml')['project']['name'])"
+        sh: python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['name'])"
     cmds:
       - echo >&2
       - echo "Inspecting wheel..." >&2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,14 +16,13 @@ authors = [
     { name = "Mihai Bojin", email = "557584+MihaiBojin@users.noreply.github.com" },
 ]
 dynamic = ["dependencies", "optional-dependencies", "version"]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@ build ==1.5.0
 pip ==26.1.2
 pre-commit ==4.6.1
 pytest ==9.1.1
-toml == 0.10.2
 twine ==6.2.0
 wheel ==0.47.0
 wheel-inspect ==1.8.0

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -56,7 +56,7 @@ build:
 	@python -m build
 
 .PHONY: build-inspect
-build-inspect: PROJECT_NAME = $(shell python -c "import toml; print(toml.load('pyproject.toml')['project']['name'])")
+build-inspect: PROJECT_NAME = $(shell python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['name'])")
 build-inspect:
 	@echo
 	@echo "Inspecting wheel..."

--- a/scripts/create-venv.bash
+++ b/scripts/create-venv.bash
@@ -14,8 +14,19 @@ if [ -d "$VENV" ]; then
     exit 0
 fi
 
+# Pick the newest supported interpreter available. A bare `python` can easily be
+# older than the 3.11 floor (a global mise or pyenv pin, say), which builds a
+# venv that cannot import tomllib.
+PYTHON=python
+for candidate in python3.14 python3.13 python3.12 python3.11; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+        PYTHON="$candidate"
+        break
+    fi
+done
+
 # Create virtualenv
-python -m venv "$VENV"
+$PYTHON -m venv "$VENV"
 
 # shellcheck disable=SC1091
 source "$VENV"/bin/activate

--- a/scripts/functions.bash
+++ b/scripts/functions.bash
@@ -27,7 +27,7 @@ get_tag_at_head() {
 # Extracts the project name as configured in 'pyproject.toml'
 get_project_name() {
     dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-    python -c "import toml; print(toml.load('$dir/../pyproject.toml')['project']['name'])"
+    python -c "import tomllib; print(tomllib.load(open('$dir/../pyproject.toml','rb'))['project']['name'])"
 }
 
 # Function to get the most recent tag from the origin repo

--- a/scripts/uninstall-package.bash
+++ b/scripts/uninstall-package.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ueo pipefail
 
-PROJECT_NAME=$(python -c "import toml; print(toml.load('pyproject.toml')['project']['name'])")
+PROJECT_NAME=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['name'])")
 echo "Uninstalling $PROJECT_NAME..."
 python -m pip uninstall -y "$PROJECT_NAME"
 echo "Done."

--- a/scripts/verify-publish.bash
+++ b/scripts/verify-publish.bash
@@ -8,7 +8,7 @@ VERSION="$(cat "$DIR"/../VERSION)"
 readonly VERSION
 
 # Load project name from project manifest
-PROJECT_NAME="$(python -c "import toml; print(toml.load('$DIR/../pyproject.toml')['project']['name'])")"
+PROJECT_NAME="$(python -c "import tomllib; print(tomllib.load(open('$DIR/../pyproject.toml','rb'))['project']['name'])")"
 readonly PROJECT_NAME
 
 # Retries a command up to 3 times


### PR DESCRIPTION
Companion to MihaiBojin/template-python-package-2024#44, which makes the same change in the template.

## What and why

Five places shelled out to `python -c "import toml; toml.load(...)"` to read the project name — `Taskfile.yml`, `scripts/Makefile`, and three bash scripts. That is the only reason `toml` was a dev dependency, and that package last released in **2020**.

```diff
-python -c "import toml; print(toml.load('pyproject.toml')['project']['name'])"
+python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['name'])"
```

`tomllib.load` requires a binary handle, hence the `'rb'`.

## The tradeoff: 3.10 support

`tomllib` entered the standard library in **3.11**, so this raises `requires-python` from `>=3.10` to `>=3.11` and drops 3.10 from the classifiers and CI matrix.

This package is published, so that is user-visible: anyone still on 3.10 can no longer install it. 3.10 reaches EOL on **2026-10-31**, three months out, and the template moved to the same floor.

## The part that would have bitten silently

`create-venv.bash` called bare `python -m venv`. On my machine that resolves through a global mise pin to **3.10.11** — so CI would have stayed green on its explicit 3.11–3.14 matrix while local venvs built an interpreter that cannot import `tomllib`.

It now prefers the newest supported interpreter (3.14 → 3.13 → 3.12 → 3.11), which is what the template's copy of the script already did. Verified: selects 3.14 here, and `shellcheck` is clean.

## Verification

Ran the rewritten command against this repo's `pyproject.toml` under 3.14 — prints `waf_downloader`, same as before. Swept for residual `import toml` and `3.10` references: none.