### PR TITLE
Fix the Helm chart release, silently skipped since 0.2.5

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -394,12 +394,32 @@ jobs:
           git config user.name "$GITHUB_ACTOR" # "github-actions[bot]"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com" # "github-actions[bot]@users.noreply.github.com"
 
+      # Chart.yaml is generated from Chart.yaml.tmpl and gitignored, so the
+      # version bump is invisible to git. chart-releaser decides what to publish
+      # by diffing tracked files under charts/, and without this commit it sees
+      # no change and silently skips the release. The commit stays local.
+      - name: Commit the generated chart version
+        run: |
+          git add --force charts/waf-downloader/Chart.yaml
+          git commit -m "Set chart version for ${GITHUB_REF_NAME}"
+
       - name: Set up Helm
         uses: azure/setup-helm@v5.0.1
 
       - name: Run chart-releaser
+        id: chart_releaser
         uses: helm/chart-releaser-action@v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           skip_existing: true
+
+      # chart-releaser exits 0 when it finds nothing to do, so a no-op is
+      # indistinguishable from a success. On a tag build it must publish.
+      - name: Verify the chart was published
+        run: |
+          if [ -z "${{ steps.chart_releaser.outputs.changed_charts }}" ]; then
+            echo "ERROR: chart-releaser published nothing on a tag build" >&2
+            exit 1
+          fi
+          echo "Published ${{ steps.chart_releaser.outputs.changed_charts }} version ${{ steps.chart_releaser.outputs.chart_version }}" >&2

--- a/scripts/helm-set-version.bash
+++ b/scripts/helm-set-version.bash
@@ -7,7 +7,11 @@ readonly DIR
 # shellcheck disable=SC1091
 source "$DIR/functions.bash"
 
+# Helm chart versions are SemVer without a leading 'v'. The published chart
+# tags and index entries all use the bare form (waf-downloader-0.2.5), so strip
+# the prefix that git::latest_version returns.
 VERSION="$(releasetools git::latest_version)"
+VERSION="${VERSION#v}"
 readonly VERSION
 
 cat "$DIR"/../charts/waf-downloader/Chart.yaml.tmpl >"$DIR"/../charts/waf-downloader/Chart.yaml


### PR DESCRIPTION
## Problem

The `Publish Helm Chart` job has been green and doing nothing since November 2024. Its entire log on the v0.3.0 release was:

```
Looking up latest tag...
Discovering changed charts since 'v0.2.24'...
Nothing to do. No chart changes detected.
```

`chart-releaser` decides what to publish by diffing **tracked** files under `charts/`. The only file that changes per release is `Chart.yaml`, which is generated from `Chart.yaml.tmpl` by `task set-chart-version` and is gitignored (`charts/waf-downloader/.gitignore`). The version bump is invisible to git, so nothing is ever detected.

Confirmed: `git diff v0.2.24 HEAD -- charts/` is empty, and the last commit touching a tracked chart file is `eb258ab` (2024-11-11) — the commit that produced chart 0.2.5.

Seven releases published no chart: `v0.2.6`, `v0.2.8`, `v0.2.11`, `v0.2.12`, `v0.2.23`, `v0.2.24`, `v0.3.0`.

## Changes

1. **Commit the generated `Chart.yaml`** before `chart-releaser` runs, making the bump visible to its change detection. The commit is local to the job and never pushed; the existing `Configure git` step already set up an identity for it.

2. **Strip the leading `v` from the chart version.** `git::latest_version` returns `v0.3.0`, but Helm chart versions are SemVer without the prefix, and every published chart uses the bare form (`waf-downloader-0.2.5`). Left as is, the first successful release would have tagged `waf-downloader-v0.3.0` and broken the convention.

3. **Fail the job when nothing is published on a tag build.** `chart-releaser` exits 0 on a no-op, which is what let this hide for over a year.

## Verification

- `task set-chart-version` now writes `version: 0.3.0` / `appVersion: 0.3.0`
- `git diff v0.2.24 -- charts/` lists `Chart.yaml` once staged, so detection will fire
- `helm lint` passes; `helm package` produces `waf-downloader-0.3.0.tgz`

The 0.3.0 chart is being published separately, since the workflow at the `v0.3.0` tag predates this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)