### PR TITLE
Make the publish verification retry actually re-query the index

### DIFF
--- a/scripts/verify-publish.bash
+++ b/scripts/verify-publish.bash
@@ -11,7 +11,15 @@ readonly VERSION
 PROJECT_NAME="$(uv run --no-project python -c "import tomllib; print(tomllib.load(open('$DIR/../pyproject.toml','rb'))['project']['name'])")"
 readonly PROJECT_NAME
 
-# Retries a command up to 3 times
+# Retries a command up to 3 times.
+#
+# The point of retrying here is to outwait index propagation: the upload has
+# just happened and the package is not listed yet. uv caches the index response
+# it gets, negative answers included, so a bare retry re-reads the cached "no
+# such version" in about 2ms and the whole ladder expires without ever asking
+# PyPI again. Callers must pass --refresh-package so each attempt is a real
+# request; pip re-fetched on its own, which is why this only began to matter
+# once the toolchain moved to uv.
 retry() {
     MAX_ATTEMPTS=4
     count=0
@@ -71,11 +79,11 @@ print(' '.join(p['dependencies'] + p.get('optional-dependencies', {}).get('cli',
             uv pip install $DEPS
         fi
         echo "Attempting install: ${PROJECT_NAME}==$VERSION"
-        retry uv pip install --index-url https://test.pypi.org/simple/ "${PROJECT_NAME}==$VERSION"
+        retry uv pip install --refresh-package "$PROJECT_NAME" --index-url https://test.pypi.org/simple/ "${PROJECT_NAME}==$VERSION"
         ;;
     --prod)
         echo "Attempting install: ${PROJECT_NAME}==$VERSION"
-        retry uv pip install "${PROJECT_NAME}[cli]==$VERSION"
+        retry uv pip install --refresh-package "$PROJECT_NAME" "${PROJECT_NAME}[cli]==$VERSION"
         ;;
     --*= | -*)
         echo "Error: Unsupported flag $1" >&2


### PR DESCRIPTION
Follow-up to #177. The v0.3.1 release published to PyPI correctly, then failed on the verification step immediately after, which skipped the Docker, GHCR, release and Helm jobs.

## What happened

`verify-publish.bash` retries the install to outwait PyPI index propagation — the upload has just happened and the new version is not listed yet. uv caches index responses, **negative answers included**, so every retry after the first re-read a cached "no such version" rather than asking PyPI.

The timings in the failed run are unambiguous:

| Attempt | Resolution time |
|---|---|
| 1 | ~70ms (a real request) |
| 2, 3, 4 | **~2ms each** (cache reads) |

All four failed inside a 31-second window without a single request reaching PyPI after the first. The package itself was fine — it installs, imports and runs.

`pip` re-fetched on its own, so this only became reachable once the toolchain moved to uv.

## The fix

Pass `--refresh-package "$PROJECT_NAME"` on both install paths, so each attempt is a real request. Scoped to the one package rather than `--refresh`, which would discard the whole cache.

The ladder now provides ~30s of genuine tolerance across 4 real attempts — strictly more than the template's `sleep 30`, which this workflow never had.

## Verified

Ran `verify-publish.bash --prod` against the real index using `v0.3.1`, the exact value CI writes to `VERSION` (uv normalises the `v` prefix): installs, reports `OK.` shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
