### PR TITLE
Limit GITHUB_TOKEN to the scopes each job actually needs

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -9,6 +9,14 @@ on:
     tags:
       - "v0.*"
 
+# Least privilege by default: the jobs that only read the repo inherit this, and
+# the ones that publish (push-docker, push-ghcr, release, helm) widen it for
+# themselves. Without a default, GITHUB_TOKEN's scopes come from the repository
+# setting, which is invisible from here and applies to every job equally.
+# see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run tests
@@ -327,6 +335,13 @@ jobs:
     needs:
       - push-docker
       - push-ghcr
+
+    # action-gh-release creates the release, and publish-sbom reads the SBOMs
+    # uploaded as artifacts by the image jobs and attaches them to it. The
+    # workflow default of contents:read is not enough for either.
+    permissions:
+      actions: read
+      contents: write
 
     steps:
       - name: Release


### PR DESCRIPTION
Fixes the four open [code scanning alerts](https://github.com/MihaiBojin/waf-downloader/security/code-scanning), all `actions/missing-workflow-permissions`: the `test`, `build`, `publish` and `release` jobs had no `permissions` block.

## Why this one matters

Without a block, a job falls back to the repository default — and this repo's default is **`write`**:

```console
$ gh api repos/MihaiBojin/waf-downloader/actions/permissions/workflow
{"default_workflow_permissions": "write", ...}
```

So all four ran with a write-capable `GITHUB_TOKEN`. The `test` job is the interesting one: it runs on `pull_request` and executes `uv run pre-commit run --all-files`, which is hook code from the PR branch. For a same-repo PR — every Renovate PR — that code ran with a token that could write to the repository.

## The fix

A workflow-level default of `contents: read`, inherited by the three read-only jobs, plus explicit scopes for `release`.

| Job | Permissions | Change |
|---|---|---|
| `test`, `build`, `publish` | `contents: read` | inherited from new workflow default |
| `release` | `contents: write`, `actions: read` | **new explicit block** |
| `push-docker`, `push-ghcr`, `helm` | unchanged | already declared their own |

## One deviation from the CodeQL hint, deliberately

For `release`, code scanning suggests an empty block (`{}`). **That would break the job.** It runs `softprops/action-gh-release` (needs `contents: write`) and `anchore/sbom-action/publish-sbom`, which reads the SBOM artifacts the image jobs upload and attaches them to the release (needs `actions: read` as well). I gave it the scopes it actually uses rather than the suggested minimum.

## Verified

YAML parses; effective permissions resolved per job and checked against what each job's steps actually call. `pre-commit run --all-files` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
