### PR TITLE
Make the chart pipeline runnable on its own

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -414,6 +414,13 @@ jobs:
           OWNER="${GITHUB_REPOSITORY%%/*}"
           REPO="${GITHUB_REPOSITORY##*/}"
 
+          # cr writes into these but does not create them; the action's wrapper
+          # script did it, and driving cr directly means doing it here. Without
+          # .cr-index, `cr index` fails writing its temp file into a directory
+          # that is not there.
+          mkdir -p .cr-release-packages
+          rm -rf .cr-index && mkdir -p .cr-index
+
           cr package charts/waf-downloader --package-path .cr-release-packages
 
           # '-c "$GITHUB_SHA"' is the fix: on a tag build that is the tagged

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -358,99 +358,12 @@ jobs:
   helm:
     name: Publish Helm Chart
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v0.')
-    runs-on: ubuntu-latest
     needs: release
 
-    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    # The chart pipeline lives in its own workflow so it can also be run on its
+    # own, for a tag that already released. Everything it needs is the tag.
+    uses: ./.github/workflows/helm-publish.yml
+    with:
+      ref: ${{ github.ref_name }}
     permissions:
       contents: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: 3.14
-
-      - uses: releasetools/cli@v0
-
-      - name: Install Task
-        uses: arduino/setup-task@v3.0.0
-        with:
-          version: 3.39.2
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set chart version
-        run: |
-          task set-chart-version
-
-      - name: Configure git
-        run: |
-          git config user.name "$GITHUB_ACTOR" # "github-actions[bot]"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com" # "github-actions[bot]@users.noreply.github.com"
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v5.0.1
-
-      # Install cr only. The action's own release step runs
-      # `cr upload -c "$(git rev-parse HEAD)"`, and its change detection diffs
-      # tracked files under charts/ against the tag being released -- which is
-      # the commit being built, so nothing ever looks changed. Driving cr
-      # directly sidesteps both: every release tag publishes its chart, targeted
-      # at a commit that exists on the remote.
-      - name: Install chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
-        with:
-          install_only: true
-
-      - name: Package and publish the chart
-        env:
-          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          OWNER="${GITHUB_REPOSITORY%%/*}"
-          REPO="${GITHUB_REPOSITORY##*/}"
-
-          # cr writes into these but does not create them; the action's wrapper
-          # script did it, and driving cr directly means doing it here. Without
-          # .cr-index, `cr index` fails writing its temp file into a directory
-          # that is not there.
-          mkdir -p .cr-release-packages
-          rm -rf .cr-index && mkdir -p .cr-index
-
-          cr package charts/waf-downloader --package-path .cr-release-packages
-
-          # '-c "$GITHUB_SHA"' is the fix: on a tag build that is the tagged
-          # commit, which GitHub can resolve. The generated Chart.yaml is
-          # gitignored, so any commit made to make it visible to git would be
-          # local to the runner, and GitHub rejects a release whose
-          # target_commitish it has never seen (422, "not a valid tag").
-          cr upload \
-            --owner "$OWNER" \
-            --git-repo "$REPO" \
-            --commit "$GITHUB_SHA" \
-            --skip-existing \
-            --package-path .cr-release-packages
-
-          cr index \
-            --owner "$OWNER" \
-            --git-repo "$REPO" \
-            --push \
-            --package-path .cr-release-packages
-
-      # '--skip-existing' makes re-runs idempotent, which also means a chart
-      # that failed to publish exits 0. On a tag build it must be there.
-      - name: Verify the chart was published
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          CHART_VERSION="$(awk '/^version:/ {print $2; exit}' charts/waf-downloader/Chart.yaml)"
-          RELEASE="waf-downloader-${CHART_VERSION}"
-          if ! gh release view "$RELEASE" --json tagName >/dev/null 2>&1; then
-            echo "ERROR: chart release '$RELEASE' was not published" >&2
-            exit 1
-          fi
-          echo "Published chart release '$RELEASE'" >&2

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -1,0 +1,126 @@
+name: Publish Helm Chart
+
+# Publishes the chart for a release tag. Called by cicd.yml as part of a
+# release, and runnable on its own for a tag that was already released.
+#
+# The chart pipeline runs last, behind the PyPI upload, so a failure there used
+# to be unrecoverable: re-running the release meant re-uploading a version PyPI
+# will not accept twice. Being able to publish a chart for an existing tag, on
+# its own, is what makes that recoverable.
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Release tag whose chart should be published, e.g. v0.3.2"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Release tag whose chart should be published, e.g. v0.3.2"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish-chart:
+    name: Package and publish
+    runs-on: ubuntu-latest
+
+    # cr creates the chart's GitHub release and pushes the index to gh-pages.
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout the release tag
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "$GITHUB_ACTOR" # "github-actions[bot]"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com" # "github-actions[bot]@users.noreply.github.com"
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5.0.1
+
+      # Install cr only. The action's own release step runs
+      # `cr upload -c "$(git rev-parse HEAD)"`, and its change detection diffs
+      # tracked files under charts/ against the tag being released -- which is
+      # the commit being built, so nothing ever looks changed. Driving cr
+      # directly sidesteps both: every release tag publishes its chart, targeted
+      # at a commit that exists on the remote.
+      - name: Install chart-releaser
+        uses: helm/chart-releaser-action@v1.7.0
+        with:
+          install_only: true
+
+      - name: Set chart version
+        run: scripts/helm-set-version.bash "${{ inputs.ref }}"
+
+      - name: Package and publish the chart
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OWNER="${GITHUB_REPOSITORY%%/*}"
+          REPO="${GITHUB_REPOSITORY##*/}"
+
+          # HEAD is the tag that was checked out, and nothing here commits, so
+          # this is a commit that exists on the remote. GitHub rejects a release
+          # whose target_commitish it has never seen (422, "not a valid tag"),
+          # which is what a runner-local commit produced.
+          TARGET_SHA="$(git rev-parse HEAD)"
+          echo "Publishing chart for ${{ inputs.ref }} at $TARGET_SHA"
+
+          # cr writes into these but does not create them; the action's wrapper
+          # script did it, and driving cr directly means doing it here. Without
+          # .cr-index, `cr index` fails writing its temp file into a directory
+          # that is not there.
+          mkdir -p .cr-release-packages
+          rm -rf .cr-index && mkdir -p .cr-index
+
+          cr package charts/waf-downloader --package-path .cr-release-packages
+
+          # '--skip-existing' keeps a re-run idempotent: the release for a tag
+          # that already published stays as it is, and only the index is redone.
+          cr upload \
+            --owner "$OWNER" \
+            --git-repo "$REPO" \
+            --commit "$TARGET_SHA" \
+            --skip-existing \
+            --package-path .cr-release-packages
+
+          cr index \
+            --owner "$OWNER" \
+            --git-repo "$REPO" \
+            --push \
+            --package-path .cr-release-packages
+
+      # '--skip-existing' means a chart that failed to publish still exits 0,
+      # and an index that was not pushed is invisible from the release alone.
+      # Check both: the release exists, and the published index resolves it.
+      - name: Verify the chart was published
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CHART_VERSION="$(awk '/^version:/ {print $2; exit}' charts/waf-downloader/Chart.yaml)"
+          RELEASE="waf-downloader-${CHART_VERSION}"
+
+          if ! gh release view "$RELEASE" --json tagName >/dev/null 2>&1; then
+            echo "ERROR: chart release '$RELEASE' was not published" >&2
+            exit 1
+          fi
+
+          # cr pushes the index from its own worktree, so the local ref is stale
+          git fetch -q origin gh-pages
+          if ! git show "origin/gh-pages:index.yaml" | grep -q "waf-downloader-${CHART_VERSION}.tgz"; then
+            echo "ERROR: '$RELEASE' is missing from the gh-pages index" >&2
+            exit 1
+          fi
+
+          echo "Published '$RELEASE' and indexed it on gh-pages" >&2

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -122,6 +122,6 @@ tasks:
       - helm template my-release charts/waf-downloader
 
   set-chart-version:
-    desc: Update the Helm chart version
+    desc: Update the Helm chart version (optionally pass a version, e.g. -- v0.3.2)
     cmds:
-      - scripts/helm-set-version.bash
+      - scripts/helm-set-version.bash {{.CLI_ARGS}}

--- a/scripts/helm-set-version.bash
+++ b/scripts/helm-set-version.bash
@@ -9,8 +9,12 @@ source "$DIR/functions.bash"
 
 # Helm chart versions are SemVer without a leading 'v'. The published chart
 # tags and index entries all use the bare form (waf-downloader-0.2.5), so strip
-# the prefix that git::latest_version returns.
-VERSION="$(releasetools git::latest_version)"
+# the prefix that a tag carries.
+#
+# Takes the version as an optional argument, falling back to the newest tag on
+# the remote. Republishing the chart for an older release has to stamp that
+# release's version, not whatever happens to be newest now.
+VERSION="${1:-$(releasetools git::latest_version)}"
 VERSION="${VERSION#v}"
 readonly VERSION
 


### PR DESCRIPTION
> Stacked on #181 — merge that first, or merge this and #181 becomes redundant.

The chart job runs last, behind the PyPI upload, so a failure there is unrecoverable: re-running the release means re-uploading a version PyPI will not accept twice.

That has now cost two releases — `0.3.1` published with no chart at all, `0.3.2` with a chart release but no index entry — and in neither case was there a way to publish just the chart.

## What changes

The chart pipeline moves into `helm-publish.yml`, taking the release tag as an input:

```yaml
on:
  workflow_call:    # cicd.yml, during a release
  workflow_dispatch:  # by hand, for a tag that already released
```

`cicd.yml`'s `helm` job becomes a call to it. It's a **reusable** workflow rather than a copy, so the release path and the manual path cannot drift.

## A bug this would otherwise have introduced

`helm-set-version.bash` derived the version from `releasetools git::latest_version` — the newest tag on the remote. That's correct during a release, and wrong for a manual re-publish: running it for `v0.3.2` after `v0.4.0` shipped would package **0.4.0** and release it as 0.3.2's chart.

It now takes the version as an optional argument and falls back to the old behaviour:

```bash
VERSION="${1:-$(releasetools git::latest_version)}"
```

Verified all three ways: `v0.3.2` → 0.3.2, bare `0.2.5` → 0.2.5, no argument → newest tag.

## Simplifications that fall out

Because the tag is an input, the job no longer needs `setup-python`, `setup-task` or `releasetools` — three steps gone. The checkout is of the tag itself, which is also what makes `git rev-parse HEAD` a commit that exists on the remote.

## Stronger verification

The old check only asked whether the chart's GitHub release existed. The `v0.3.2` failure created the release and left the index untouched — **that check would have passed**. It now also confirms the chart resolves in the published `gh-pages` index.

## After merging

Run it for the release that's currently half-published:

```
gh workflow run helm-publish.yml -f ref=v0.3.2
```

`--skip-existing` makes that safe: the existing `waf-downloader-0.3.2` release is left alone and only the index is written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
