### PR TITLE
Stop the chart release from claiming 'latest'

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -111,10 +111,16 @@ jobs:
 
           # '--skip-existing' keeps a re-run idempotent: the release for a tag
           # that already published stays as it is, and only the index is redone.
+          #
+          # '--make-release-latest=false' because cr defaults it to true, and
+          # this job runs after `release` has already marked the product release
+          # as latest. Left alone, the chart release takes that badge -- which
+          # is what /releases/latest currently resolves to.
           cr upload \
             --owner "$OWNER" \
             --git-repo "$REPO" \
             --commit "$TARGET_SHA" \
+            --make-release-latest=false \
             --skip-existing \
             --package-path .cr-release-packages
 


### PR DESCRIPTION
`/releases/latest` on this repository resolved to `waf-downloader-0.3.3`, the
chart release, rather than `v0.3.3`:

```console
$ gh api repos/MihaiBojin/waf-downloader/releases/latest --jq .tag_name
waf-downloader-0.3.3
```

So anything that asks GitHub for the newest release -- the sidebar on the
repository page, install instructions that resolve `/releases/latest`, release
notifications -- pointed at a packaged Helm chart instead of the release it
belongs to.

## Cause

`cr upload` defaults `--make-release-latest` to true (`cr/cmd/upload.go` in
chart-releaser v1.7.0):

    uploadCmd.Flags().Bool("make-release-latest", true, "Mark the created GitHub release as 'latest'")

and it reaches the API as `MakeLatest` in `pkg/releaser/releaser.go`. Since the
chart is published after `release` has already run `action-gh-release` with
`make_latest: true`, whichever ran last wins -- and that is always the chart.

Passing `--make-release-latest=false` leaves the badge where `release` put it.
Nothing else about the chart release changes: it is still created, still tagged
`waf-downloader-<version>`, still indexed on `gh-pages`.

## The existing releases

Already corrected out of band, so this PR only has to keep it from happening
again:

```console
$ gh release edit v0.3.3 --latest
$ gh api repos/MihaiBojin/waf-downloader/releases/latest --jq .tag_name
v0.3.3
```

Note that `#182` is not implicated -- it fixed the `.cr-index` ENOENT that
failed the v0.3.2 chart release, which is a different bug in the same job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)