### PR TITLE
Stamp the chart version without the tag's own tooling

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -60,8 +60,31 @@ jobs:
         with:
           install_only: true
 
+      # Stamped inline rather than via scripts/helm-set-version.bash, because
+      # this workflow checks out the tag and would therefore run *that tag's*
+      # copy of the script. Tags cut before the script learned to take a version
+      # ignore the argument and read the newest tag instead -- so republishing
+      # v0.3.2 either fails on a missing releasetools, or silently packages the
+      # newest version under the old one's name. Keep this in step with
+      # scripts/helm-set-version.bash, which serves the same template locally.
       - name: Set chart version
-        run: scripts/helm-set-version.bash "${{ inputs.ref }}"
+        env:
+          REF: ${{ inputs.ref }}
+        run: |
+          VERSION="${REF#v}"
+          CHART="charts/waf-downloader"
+
+          sed -e "s/version: \"{{ VERSION }}\"/version: $VERSION/" \
+              -e "s/appVersion: \"{{ VERSION }}\"/appVersion: $VERSION/" \
+              "$CHART/Chart.yaml.tmpl" >"$CHART/Chart.yaml"
+
+          # A leftover placeholder means the template changed shape; packaging
+          # would fail later with something far less obvious than this.
+          if grep -q "{{ VERSION }}" "$CHART/Chart.yaml"; then
+            echo "ERROR: unsubstituted placeholder left in Chart.yaml" >&2
+            exit 1
+          fi
+          grep -E "^(version|appVersion):" "$CHART/Chart.yaml"
 
       - name: Package and publish the chart
         env:


### PR DESCRIPTION
The first `workflow_dispatch` run — republishing `v0.3.2`'s chart — [failed](https://github.com/MihaiBojin/waf-downloader/actions/runs/30491809844):

```
scripts/helm-set-version.bash: line 13: releasetools: command not found
```

## Cause: a design flaw in #182, not a typo

`helm-publish.yml` checks out the tag it is publishing, so it runs **that tag's** copy of the scripts — not the ones it was written against. On `main`, line 13 is a comment; at `v0.3.2` it is the pre-#182 version:

```bash
VERSION="$(releasetools git::latest_version)"   # line 13 at v0.3.2
```

That takes no argument and shells out to `releasetools` — a step #182 removed, precisely *because* passing the version in had made it unnecessary. The argument support that makes a republish correct lives on `main`; the script that executes comes from the tag. The fix was never reachable.

**Installing `releasetools` would not have fixed this, only hidden it.** That script reads the *newest* tag, so republishing `v0.3.2` would have packaged **0.3.3** and released it as 0.3.2's chart — quietly wrong instead of loudly broken.

Note this does not affect the release path: on a tag push the tag and the workflow are the same commit, which is why `v0.3.3` published cleanly. It only breaks republishing older tags — which is the entire reason the dispatch exists.

## Fix

Substitute the template in the workflow. The version comes from the input the workflow already has, so publishing an old tag no longer depends on what its tooling could do at the time. The only thing still taken from the tag is `charts/`, which is the point.

A guard fails loudly on an unsubstituted placeholder, since the alternative is a confusing error much later in packaging.

The placeholders are identical at `v0.3.2` and `main` (`version: "{{ VERSION }}"`, lines 5–6), so this works for the existing tags.

## Verified against the real v0.3.2 tree

Extracted `charts/` from the `v0.3.2` tag and ran the workflow's exact commands:

| Check | Result |
|---|---|
| Version stamped | `0.3.2` — **not** 0.3.3 |
| Placeholders remaining | none |
| `cr package` | `waf-downloader-0.3.2.tgz` |
| `helm show chart` | `version: 0.3.2`, `appVersion: 0.3.2` |

Also confirmed the step's YAML escaping survives parsing and the resulting shell passes `bash -n`.

`scripts/helm-set-version.bash` stays for `task set-chart-version`, which the `helm-lint` hook uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
